### PR TITLE
Api changes

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -130,7 +130,8 @@ static void dorepl(bool ignoreEnv) {
 
 // ---- Script execution ----
 
-static EvalResult execScript(const char* script, int argsCount, const char** args, bool ignoreEnv) {
+static JStarResult execScript(const char* script, int argsCount, const char** args,
+                              bool ignoreEnv) {
     jsrInitCommandLineArgs(vm, argsCount, args);
 
     // set base import path to script's directory
@@ -152,7 +153,7 @@ static EvalResult execScript(const char* script, int argsCount, const char** arg
         exit(EXIT_FAILURE);
     }
 
-    EvalResult res = jsrEvaluate(vm, script, src);
+    JStarResult res = jsrEvaluate(vm, script, src);
     free(src);
     return res;
 }
@@ -217,14 +218,14 @@ int main(int argc, const char** argv) {
         exit(EXIT_SUCCESS);
     }
     if(opts.execStmt) {
-        EvalResult res = jsrEvaluate(vm, "<string>", opts.execStmt);
-        if(opts.script && res == VM_EVAL_SUCCESS) {
+        JStarResult res = jsrEvaluate(vm, "<string>", opts.execStmt);
+        if(opts.script && res == JSR_EVAL_SUCCESS) {
             res = execScript(opts.script, opts.argsCount, opts.args, opts.ignoreEnv);
         }
         if(!opts.interactive) exit(res);
     }
     if(opts.script && !opts.execStmt) {
-        EvalResult res = execScript(opts.script, opts.argsCount, opts.args, opts.ignoreEnv);
+        JStarResult res = execScript(opts.script, opts.argsCount, opts.args, opts.ignoreEnv);
         if(!opts.interactive) exit(res);
     }
 

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -88,7 +88,7 @@ static int countBlocks(const char* line) {
 }
 
 static void addPrintIfExpr(JStarBuffer* sb) {
-    Expr* e = parseExpression(NULL, sb->data);
+    Expr* e = parseExpression("<repl>", sb->data, NULL);
     if(e != NULL) {
         jsrBufferPrependstr(sb, "var _ = ");
         jsrBufferAppendstr(sb, "\nif _ != null then print(_) end");

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -201,6 +201,7 @@ CLIOpts parseArguments(int argc, const char** argv) {
     if(nonOptsCount > 0) {
         opts.script = argv[0];
     }
+
     if(nonOptsCount > 1) {
         opts.args = &argv[1];
         opts.argsCount = nonOptsCount - 1;
@@ -211,23 +212,35 @@ CLIOpts parseArguments(int argc, const char** argv) {
 
 int main(int argc, const char** argv) {
     CLIOpts opts = parseArguments(argc, argv);
-    vm = jsrNewVM();
 
     if(opts.showVersion) {
         printVersion();
         exit(EXIT_SUCCESS);
     }
+
+    JStarConf conf;
+    jsrInitConf(&conf);
+    vm = jsrNewVM(&conf);
+
     if(opts.execStmt) {
         JStarResult res = jsrEvaluate(vm, "<string>", opts.execStmt);
         if(opts.script && res == JSR_EVAL_SUCCESS) {
             res = execScript(opts.script, opts.argsCount, opts.args, opts.ignoreEnv);
         }
-        if(!opts.interactive) exit(res);
+        if(!opts.interactive) {
+            jsrFreeVM(vm);
+            exit(res);
+        }
     }
+
     if(opts.script && !opts.execStmt) {
         JStarResult res = execScript(opts.script, opts.argsCount, opts.args, opts.ignoreEnv);
-        if(!opts.interactive) exit(res);
+        if(!opts.interactive) {
+            jsrFreeVM(vm);
+            exit(res);
+        }
     }
 
     dorepl(opts.ignoreEnv);
+    jsrFreeVM(vm);
 }

--- a/jstar/include/jsrparse/parser.h
+++ b/jstar/include/jsrparse/parser.h
@@ -4,9 +4,9 @@
 #include "ast.h"
 #include "jstarconf.h"
 
-typedef void (*ParseErrorFun)(const char* file, int line, const char* error);
+typedef void (*ParseErrorCB)(const char* file, int line, const char* error);
 
-JSTAR_API Stmt* parse(const char* path, const char* src, ParseErrorFun errorFun);
-JSTAR_API Expr* parseExpression(const char* path, const char* src, ParseErrorFun errorFun);
+JSTAR_API Stmt* parse(const char* path, const char* src, ParseErrorCB errorFun);
+JSTAR_API Expr* parseExpression(const char* path, const char* src, ParseErrorCB errorFun);
 
 #endif

--- a/jstar/include/jsrparse/parser.h
+++ b/jstar/include/jsrparse/parser.h
@@ -4,7 +4,9 @@
 #include "ast.h"
 #include "jstarconf.h"
 
-JSTAR_API Stmt* parse(const char* fname, const char* src);
-JSTAR_API Expr* parseExpression(const char* fname, const char* src);
+typedef void (*ParseErrorFun)(const char* file, int line, const char* error);
+
+JSTAR_API Stmt* parse(const char* path, const char* src, ParseErrorFun errorFun);
+JSTAR_API Expr* parseExpression(const char* path, const char* src, ParseErrorFun errorFun);
 
 #endif

--- a/jstar/include/jstar.h
+++ b/jstar/include/jstar.h
@@ -46,16 +46,16 @@ typedef enum JStarResult {
 } JStarResult;
 
 // J* error function callback
-typedef void (*JStarErrorFun)(const char* file, int line, const char* error);
+typedef void (*JStarErrorCB)(const char* file, int line, const char* error);
 
 // Default implementation of error callback that prints the error to stderr
 JSTAR_API void jsrPrintErrorCB(const char* file, int line, const char* error);
 
 typedef struct JstarConf {
-    size_t stackSize;        // Initial stack size in bytes
-    size_t initGC;           // first GC threshold point
-    int heapGrowRate;        // The rate at which the heap will grow after a succesful GC
-    JStarErrorFun errorFun;  // Error callback
+    size_t stackSize;            // Initial stack size in bytes
+    size_t initGC;               // first GC threshold point
+    int heapGrowRate;            // The rate at which the heap will grow after a succesful GC
+    JStarErrorCB errorCallback;  // Error callback
 } JStarConf;
 
 // Initialize configuration with default values

--- a/jstar/include/jstar.h
+++ b/jstar/include/jstar.h
@@ -38,15 +38,28 @@
 // The J* virtual machine
 typedef struct JStarVM JStarVM;
 
-typedef enum {
+typedef enum JStarResult {
     JSR_EVAL_SUCCESS,  // The VM successfully executed the code
     JSR_SYNTAX_ERR,    // A syntax error has been encountered in parsing
     JSR_COMPILE_ERR,   // An error has been encountered during compilation
     JSR_RUNTIME_ERR,   // An unhandled exception has reached the top of the stack
 } JStarResult;
 
+typedef void (*JStarErrorFun)(JStarVM* vm, JStarResult errorCode, const char* file, int line,
+                              const char* error);
+
+typedef struct JstarConf {
+    size_t stackSize;        // Initial stack size in bytes
+    size_t initGC;           // first GC threshold point
+    int heapGrowRate;        // The rate at which the heap will grow after a succesful GC
+    JStarErrorFun errorFun;  // Error callback
+} JStarConf;
+
+// Initialize configuration with default values
+JSTAR_API void jsrInitConf(JStarConf* conf);
+
 // Allocate a new VM with all the state needed for code execution
-JSTAR_API JStarVM* jsrNewVM();
+JSTAR_API JStarVM* jsrNewVM(JStarConf* conf);
 // Free a previously obtained VM along with all the state
 JSTAR_API void jsrFreeVM(JStarVM* vm);
 

--- a/jstar/include/jstar.h
+++ b/jstar/include/jstar.h
@@ -45,8 +45,11 @@ typedef enum JStarResult {
     JSR_RUNTIME_ERR,   // An unhandled exception has reached the top of the stack
 } JStarResult;
 
-typedef void (*JStarErrorFun)(JStarVM* vm, JStarResult errorCode, const char* file, int line,
-                              const char* error);
+// J* error function callback
+typedef void (*JStarErrorFun)(const char* file, int line, const char* error);
+
+// Default implementation of error callback that prints the error to stderr
+JSTAR_API void jsrPrintErrorCB(const char* file, int line, const char* error);
 
 typedef struct JstarConf {
     size_t stackSize;        // Initial stack size in bytes
@@ -68,8 +71,8 @@ JSTAR_API void jsrFreeVM(JStarVM* vm);
 // VM_EVAL_SUCCSESS will be returned if the execution completed normally
 // In case of errors, either VM_SYNTAX_ERR, VM_COMPILE_ERR or VM_RUNTIME_ERR
 // will be returned, and all the errors will be printed to stderr.
-JSTAR_API JStarResult jsrEvaluate(JStarVM* vm, const char* fpath, const char* src);
-JSTAR_API JStarResult jsrEvaluateModule(JStarVM* vm, const char* fpath, const char* name,
+JSTAR_API JStarResult jsrEvaluate(JStarVM* vm, const char* path, const char* src);
+JSTAR_API JStarResult jsrEvaluateModule(JStarVM* vm, const char* path, const char* name,
                                         const char* src);
 
 // Call a function (or method with name "name") that sits on the top of the stack

--- a/jstar/include/jstar.h
+++ b/jstar/include/jstar.h
@@ -39,11 +39,11 @@
 typedef struct JStarVM JStarVM;
 
 typedef enum {
-    VM_EVAL_SUCCESS,  // The VM successfully executed the code
-    VM_SYNTAX_ERR,    // A syntax error has been encountered in parsing
-    VM_COMPILE_ERR,   // An error has been encountered during compilation
-    VM_RUNTIME_ERR,   // An unhandled exception has reached the top of the stack
-} EvalResult;
+    JSR_EVAL_SUCCESS,  // The VM successfully executed the code
+    JSR_SYNTAX_ERR,    // A syntax error has been encountered in parsing
+    JSR_COMPILE_ERR,   // An error has been encountered during compilation
+    JSR_RUNTIME_ERR,   // An unhandled exception has reached the top of the stack
+} JStarResult;
 
 // Allocate a new VM with all the state needed for code execution
 JSTAR_API JStarVM* jsrNewVM();
@@ -55,9 +55,9 @@ JSTAR_API void jsrFreeVM(JStarVM* vm);
 // VM_EVAL_SUCCSESS will be returned if the execution completed normally
 // In case of errors, either VM_SYNTAX_ERR, VM_COMPILE_ERR or VM_RUNTIME_ERR
 // will be returned, and all the errors will be printed to stderr.
-JSTAR_API EvalResult jsrEvaluate(JStarVM* vm, const char* fpath, const char* src);
-JSTAR_API EvalResult jsrEvaluateModule(JStarVM* vm, const char* fpath, const char* name,
-                                       const char* src);
+JSTAR_API JStarResult jsrEvaluate(JStarVM* vm, const char* fpath, const char* src);
+JSTAR_API JStarResult jsrEvaluateModule(JStarVM* vm, const char* fpath, const char* name,
+                                        const char* src);
 
 // Call a function (or method with name "name") that sits on the top of the stack
 // along with its arguments. The state of the stack when calling should be:
@@ -72,8 +72,8 @@ JSTAR_API EvalResult jsrEvaluateModule(JStarVM* vm, const char* fpath, const cha
 //
 // If an exception has been raised by the code, VM_RUNTIME_ERR will be returned and
 // The exception will be placed on top of the stack as a result.
-JSTAR_API EvalResult jsrCall(JStarVM* vm, uint8_t argc);
-JSTAR_API EvalResult jsrCallMethod(JStarVM* vm, const char* name, uint8_t argc);
+JSTAR_API JStarResult jsrCall(JStarVM* vm, uint8_t argc);
+JSTAR_API JStarResult jsrCallMethod(JStarVM* vm, const char* name, uint8_t argc);
 
 // Prints the the stack trace of the exception at slot 'slot'
 JSTAR_API void jsrPrintStacktrace(JStarVM* vm, int slot);

--- a/jstar/src/builtin/debug.jsr.h
+++ b/jstar/src/builtin/debug.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/debug.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/builtin/debug.jsr". Do not modify.
 const char *debug_jsr =
 "native printStack()\n"
 "native disassemble(func)\n"

--- a/jstar/src/builtin/debug.jsr.h
+++ b/jstar/src/builtin/debug.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/builtin/debug.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/debug.jsr". Do not modify.
 const char *debug_jsr =
 "native printStack()\n"
 "native disassemble(func)\n"

--- a/jstar/src/builtin/io.c
+++ b/jstar/src/builtin/io.c
@@ -349,7 +349,7 @@ JSR_NATIVE(jsr_popen) {
 
     jsrGetGlobal(vm, NULL, "__PFile");
     jsrPushHandle(vm, f);
-    if(jsrCall(vm, 1) != VM_EVAL_SUCCESS) return false;
+    if(jsrCall(vm, 1) != JSR_EVAL_SUCCESS) return false;
     return true;
 }
 
@@ -358,7 +358,7 @@ static bool createStdFile(JStarVM* vm, const char* name, FILE* stdfile) {
     jsrPushNull(vm);
     jsrPushNull(vm);
     jsrPushHandle(vm, stdfile);
-    if(jsrCall(vm, 3) != VM_EVAL_SUCCESS) return false;
+    if(jsrCall(vm, 3) != JSR_EVAL_SUCCESS) return false;
     jsrSetGlobal(vm, NULL, name);
     jsrPop(vm);
     return true;

--- a/jstar/src/builtin/io.jsr.h
+++ b/jstar/src/builtin/io.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/io.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/builtin/io.jsr". Do not modify.
 const char *io_jsr =
 "class IOException is Exception end\n"
 "class FileNotFoundException is IOException end\n"

--- a/jstar/src/builtin/io.jsr.h
+++ b/jstar/src/builtin/io.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/builtin/io.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/io.jsr". Do not modify.
 const char *io_jsr =
 "class IOException is Exception end\n"
 "class FileNotFoundException is IOException end\n"

--- a/jstar/src/builtin/math.jsr.h
+++ b/jstar/src/builtin/math.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/math.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/builtin/math.jsr". Do not modify.
 const char *math_jsr =
 "native abs(x)\n"
 "native acos(x)\n"

--- a/jstar/src/builtin/math.jsr.h
+++ b/jstar/src/builtin/math.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/builtin/math.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/math.jsr". Do not modify.
 const char *math_jsr =
 "native abs(x)\n"
 "native acos(x)\n"

--- a/jstar/src/builtin/re.c
+++ b/jstar/src/builtin/re.c
@@ -470,7 +470,7 @@ static bool subCall(JStarVM* vm, RegexState* rs, JStarBuffer* b, int funSlot) {
     for(int i = 1; i < rs->capturec; i++) {
         if(!pushCapture(vm, rs, i)) return false;
     }
-    if(jsrCall(vm, rs->capturec - 1) != VM_EVAL_SUCCESS) return false;
+    if(jsrCall(vm, rs->capturec - 1) != JSR_EVAL_SUCCESS) return false;
     JSR_CHECK(String, -1, "sub() return value");
     jsrBufferAppendstr(b, jsrGetString(vm, -1));
     jsrPop(vm);

--- a/jstar/src/builtin/re.jsr.h
+++ b/jstar/src/builtin/re.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/re.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/builtin/re.jsr". Do not modify.
 const char *re_jsr =
 "class RegexException is Exception end\n"
 "native match(str, regex, off=0)\n"

--- a/jstar/src/builtin/re.jsr.h
+++ b/jstar/src/builtin/re.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/builtin/re.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/re.jsr". Do not modify.
 const char *re_jsr =
 "class RegexException is Exception end\n"
 "native match(str, regex, off=0)\n"

--- a/jstar/src/builtin/sys.jsr.h
+++ b/jstar/src/builtin/sys.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/builtin/sys.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/sys.jsr". Do not modify.
 const char *sys_jsr =
 "import io\n"
 "var args = []\n"

--- a/jstar/src/builtin/sys.jsr.h
+++ b/jstar/src/builtin/sys.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/builtin/sys.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/builtin/sys.jsr". Do not modify.
 const char *sys_jsr =
 "import io\n"
 "var args = []\n"

--- a/jstar/src/common.h
+++ b/jstar/src/common.h
@@ -10,6 +10,7 @@
 #define FRAME_SZ        100                        // Starting frame size
 #define STACK_SZ        FRAME_SZ*(MAX_LOCALS + 1)  // Stack size given frames
 #define INIT_GC         (1024 * 1024 * 10)         // 10MiB - First GC collection point
+#define HEAP_GROW_RATE  2                          // The heap growing rate
 #define HANDLER_MAX     10                         // Max number of try-excepts for a frame
 #define INTERN_TRESHOLD 256                        // Under this size a string is always interned
 

--- a/jstar/src/common.h
+++ b/jstar/src/common.h
@@ -17,16 +17,15 @@
 // Compiler constants
 #define MAX_TRY_DEPTH HANDLER_MAX  // Max depth of nested trys
 #define MAX_LOCALS    UINT8_MAX    // At most 255 local vars per frame
+#define MAX_ERR       512
 
 // String constants
-#define CTOR_STR    "new"
-#define THIS_STR    "this"
-#define ANON_PREFIX "anon@"
-
+#define CTOR_STR         "new"
+#define THIS_STR         "this"
+#define ANON_PREFIX      "anon@"
 #define EXC_M_ERR        "_err"
 #define EXC_M_STACKTRACE "_stacktrace"
-
-#define PACKAGE_FILE "/__package__.jsr"
+#define PACKAGE_FILE     "/__package__.jsr"
 
 #ifdef __unix__
     #define DL_PREFIX "lib"

--- a/jstar/src/compiler.c
+++ b/jstar/src/compiler.c
@@ -110,7 +110,7 @@ static void error(Compiler* c, int line, const char* format, ...) {
     va_end(args);
 
     JStarVM* vm = c->vm;
-    if(vm->errorFun) vm->errorFun(c->filename, line, errorMessage);
+    if(vm->errorCallback) vm->errorCallback(c->filename, line, errorMessage);
     c->hadError = true;
 }
 

--- a/jstar/src/compiler.c
+++ b/jstar/src/compiler.c
@@ -73,7 +73,7 @@ struct Compiler {
 static ObjFunction* function(Compiler* c, ObjModule* module, Stmt* s);
 static ObjFunction* method(Compiler* c, ObjModule* module, Identifier* classId, Stmt* s);
 
-static void initCompiler(Compiler* c, Compiler* prev, FuncType t, int depth, JStarVM* vm) {
+static void initCompiler(Compiler* c, JStarVM* vm, Compiler* prev, FuncType t, int depth) {
     c->vm = vm;
     c->type = t;
     c->func = NULL;
@@ -97,7 +97,7 @@ static void endCompiler(Compiler* c) {
 
 ObjFunction* compile(JStarVM* vm, ObjModule* module, Stmt* s) {
     Compiler c;
-    initCompiler(&c, NULL, TYPE_FUNC, -1, vm);
+    initCompiler(&c, vm, NULL, TYPE_FUNC, -1);
     ObjFunction* func = function(&c, module, s);
     endCompiler(&c);
     return c.hadError ? NULL : func;
@@ -1057,7 +1057,7 @@ static void compileWhileStatement(Compiler* c, Stmt* s) {
 
 static void compileFunction(Compiler* c, Stmt* s) {
     Compiler compiler;
-    initCompiler(&compiler, c, TYPE_FUNC, c->depth + 1, c->vm);
+    initCompiler(&compiler, c->vm, c, TYPE_FUNC, c->depth + 1);
 
     ObjFunction* func = function(&compiler, c->func->c.module, s);
 
@@ -1102,7 +1102,7 @@ static void compileMethods(Compiler* c, Stmt* cls) {
         Stmt* m = (Stmt*)n->elem;
         switch(m->type) {
         case FUNCDECL: {
-            initCompiler(&methCompiler, c, TYPE_METHOD, c->depth + 1, c->vm);
+            initCompiler(&methCompiler, c->vm, c, TYPE_METHOD, c->depth + 1);
 
             ObjFunction* meth = method(&methCompiler, c->func->c.module, &cls->as.classDecl.id, m);
 

--- a/jstar/src/compiler.h
+++ b/jstar/src/compiler.h
@@ -7,7 +7,7 @@
 
 typedef struct Compiler Compiler;
 
-ObjFunction* compile(JStarVM* vm, ObjModule* module, Stmt* s);
+ObjFunction* compile(JStarVM* vm, const char* filename, ObjModule* module, Stmt* s);
 void reachCompilerRoots(JStarVM* vm, Compiler* c);
 
 #endif

--- a/jstar/src/core.c
+++ b/jstar/src/core.c
@@ -242,7 +242,7 @@ JSR_NATIVE(jsr_eval) {
     else
         mod = AS_NATIVE(prevFrame->fn)->c.module;
 
-    Stmt* program = parse("<eval>", jsrGetString(vm, 1), vm->errorFun);
+    Stmt* program = parse("<eval>", jsrGetString(vm, 1), vm->errorCallback);
     if(program == NULL) {
         JSR_RAISE(vm, "SyntaxException", "Syntax error");
     }

--- a/jstar/src/core.c
+++ b/jstar/src/core.c
@@ -242,12 +242,12 @@ JSR_NATIVE(jsr_eval) {
     else
         mod = AS_NATIVE(prevFrame->fn)->c.module;
 
-    Stmt* program = parse("<eval>", jsrGetString(vm, 1));
+    Stmt* program = parse("<eval>", jsrGetString(vm, 1), vm->errorFun);
     if(program == NULL) {
         JSR_RAISE(vm, "SyntaxException", "Syntax error");
     }
 
-    ObjFunction* fn = compileWithModule(vm, mod->name, program);
+    ObjFunction* fn = compileWithModule(vm, "<eval>", mod->name, program);
     freeStmt(program);
 
     if(fn == NULL) {

--- a/jstar/src/core.c
+++ b/jstar/src/core.c
@@ -204,7 +204,7 @@ JSR_NATIVE(jsr_ascii) {
 
 JSR_NATIVE(jsr_print) {
     jsrPushValue(vm, 1);
-    if(jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS) return false;
+    if(jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS) return false;
     if(!jsrIsString(vm, -1)) {
         JSR_RAISE(vm, "TypeException", "s.__string__() didn't return a String");
     }
@@ -214,7 +214,7 @@ JSR_NATIVE(jsr_print) {
 
     JSR_FOREACH(
         2, {
-            if(jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS) return false;
+            if(jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS) return false;
             if(!jsrIsString(vm, -1)) {
                 JSR_RAISE(vm, "TypeException", "__string__() didn't return a String");
             }
@@ -258,9 +258,9 @@ JSR_NATIVE(jsr_eval) {
     ObjClosure* closure = newClosure(vm, fn);
     pop(vm);
 
-    EvalResult res;
+    JStarResult res;
     push(vm, OBJ_VAL(closure));
-    if((res = jsrCall(vm, 0)) != VM_EVAL_SUCCESS) return false;
+    if((res = jsrCall(vm, 0)) != JSR_EVAL_SUCCESS) return false;
     pop(vm);
 
     jsrPushNull(vm);
@@ -465,7 +465,7 @@ JSR_NATIVE(jsr_List_new) {
         for(size_t i = 0; i < lst->count; i++) {
             jsrPushValue(vm, 2);
             jsrPushNumber(vm, i);
-            if(jsrCall(vm, 1) != VM_EVAL_SUCCESS) return false;
+            if(jsrCall(vm, 1) != JSR_EVAL_SUCCESS) return false;
             lst->arr[i] = pop(vm);
         }
     } else {
@@ -675,7 +675,7 @@ JSR_NATIVE(jsr_Tuple_hash) {
     uint32_t hash = 1;
     for(size_t i = 0; i < tup->size; i++) {
         push(vm, tup->arr[i]);
-        if(jsrCallMethod(vm, "__hash__", 0) != VM_EVAL_SUCCESS) return false;
+        if(jsrCallMethod(vm, "__hash__", 0) != JSR_EVAL_SUCCESS) return false;
         JSR_CHECK(Number, -1, "__hash__() return value");
         uint32_t elemHash = jsrGetNumber(vm, -1);
         pop(vm);
@@ -696,7 +696,7 @@ JSR_NATIVE(jsr_String_new) {
     JSR_FOREACH(
         1,
         {
-            if(jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS) {
+            if(jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS) {
                 jsrBufferFree(&string);
                 return false;
             }
@@ -847,7 +847,7 @@ JSR_NATIVE(jsr_String_join) {
         1,
         {
             if(!jsrIsString(vm, -1)) {
-                if((jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS)) {
+                if((jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS)) {
                     jsrBufferFree(&joined);
                     return false;
                 }
@@ -967,7 +967,7 @@ static bool tableKeyHash(JStarVM* vm, Value key, uint32_t* hash) {
     }
 
     push(vm, key);
-    if(jsrCallMethod(vm, "__hash__", 0) != VM_EVAL_SUCCESS) return false;
+    if(jsrCallMethod(vm, "__hash__", 0) != JSR_EVAL_SUCCESS) return false;
     JSR_CHECK(Number, -1, "__hash__() return value");
     *hash = (uint32_t)jsrGetNumber(vm, -1);
     pop(vm);
@@ -1002,7 +1002,7 @@ static bool tableKeyEquals(JStarVM* vm, Value k1, Value k2, bool* eq) {
 
     push(vm, k1);
     push(vm, k2);
-    if(jsrCallMethod(vm, "__eq__", 1) != VM_EVAL_SUCCESS) return false;
+    if(jsrCallMethod(vm, "__eq__", 1) != JSR_EVAL_SUCCESS) return false;
     *eq = isValTrue(*--vm->sp);
     return true;
 }
@@ -1271,7 +1271,7 @@ JSR_NATIVE(jsr_Table_string) {
         for(size_t i = 0; i < t->sizeMask + 1; i++) {
             if(!IS_NULL(entries[i].key)) {
                 push(vm, entries[i].key);
-                if(jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS || !jsrIsString(vm, -1)) {
+                if(jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS || !jsrIsString(vm, -1)) {
                     jsrBufferFree(&buf);
                     return false;
                 }
@@ -1280,7 +1280,7 @@ JSR_NATIVE(jsr_Table_string) {
                 jsrPop(vm);
 
                 push(vm, entries[i].val);
-                if(jsrCallMethod(vm, "__string__", 0) != VM_EVAL_SUCCESS || !jsrIsString(vm, -1)) {
+                if(jsrCallMethod(vm, "__string__", 0) != JSR_EVAL_SUCCESS || !jsrIsString(vm, -1)) {
                     jsrBufferFree(&buf);
                     return false;
                 }
@@ -1350,7 +1350,7 @@ JSR_NATIVE(jsr_Enum_new) {
             if(customEnum) {
                 jsrPushValue(vm, 2);
                 jsrPushValue(vm, -2);
-                if(jsrCallMethod(vm, "__get__", 1) != VM_EVAL_SUCCESS) return false;
+                if(jsrCallMethod(vm, "__get__", 1) != JSR_EVAL_SUCCESS) return false;
             } else {
                 jsrPushNumber(vm, i);
             }
@@ -1363,13 +1363,13 @@ JSR_NATIVE(jsr_Enum_new) {
             if(customEnum) {
                 jsrPushValue(vm, 2);
                 jsrPushValue(vm, -3);
-                if(jsrCallMethod(vm, "__get__", 1) != VM_EVAL_SUCCESS) return false;
+                if(jsrCallMethod(vm, "__get__", 1) != JSR_EVAL_SUCCESS) return false;
             } else {
                 jsrPushNumber(vm, i);
             }
 
             jsrPushValue(vm, -3);
-            if(jsrCallMethod(vm, "__set__", 2) != VM_EVAL_SUCCESS) return false;
+            if(jsrCallMethod(vm, "__set__", 2) != JSR_EVAL_SUCCESS) return false;
             jsrPop(vm);
 
             jsrPop(vm);
@@ -1391,7 +1391,7 @@ JSR_NATIVE(jsr_Enum_value) {
 JSR_NATIVE(jsr_Enum_name) {
     if(!jsrGetField(vm, 0, M_VALUE_NAME)) return false;
     jsrPushValue(vm, 1);
-    if(jsrCallMethod(vm, "__get__", 1) != VM_EVAL_SUCCESS) return false;
+    if(jsrCallMethod(vm, "__get__", 1) != JSR_EVAL_SUCCESS) return false;
     return true;
 }
 // end

--- a/jstar/src/core.jsr.h
+++ b/jstar/src/core.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "D:/Workspace/c/jstar/jstar/src/core.jsr". Do not modify.
+// "/home/fabrizio/Workspace/c/jstar/jstar/src/core.jsr". Do not modify.
 const char *core_jsr =
 "class Number\n"
 "    native new(n)\n"

--- a/jstar/src/core.jsr.h
+++ b/jstar/src/core.jsr.h
@@ -1,5 +1,5 @@
 // WARNING: this is a file generated automatically by the build process from
-// "/home/fabrizio/Workspace/c/jstar/jstar/src/core.jsr". Do not modify.
+// "/mnt/HDD/Workspace/c/jstar/jstar/src/core.jsr". Do not modify.
 const char *core_jsr =
 "class Number\n"
 "    native new(n)\n"

--- a/jstar/src/import.c
+++ b/jstar/src/import.c
@@ -91,7 +91,7 @@ static void tryNativeLib(JStarVM* vm, JStarBuffer* modulePath, ObjString* module
 }
 
 static bool importWithSource(JStarVM* vm, const char* path, ObjString* name, const char* source) {
-    Stmt* program = parse(path, source, vm->errorFun);
+    Stmt* program = parse(path, source, vm->errorCallback);
 
     if(program == NULL) {
         return false;

--- a/jstar/src/import.c
+++ b/jstar/src/import.c
@@ -14,7 +14,7 @@
 #include "value.h"
 #include "vm.h"
 
-ObjFunction* compileWithModule(JStarVM* vm, ObjString* name, Stmt* program) {
+ObjFunction* compileWithModule(JStarVM* vm, const char* filename, ObjString* name, Stmt* program) {
     ObjModule* module = getModule(vm, name);
 
     if(module == NULL) {
@@ -30,7 +30,7 @@ ObjFunction* compileWithModule(JStarVM* vm, ObjString* name, Stmt* program) {
     }
 
     if(program != NULL) {
-        ObjFunction* fn = compile(vm, module, program);
+        ObjFunction* fn = compile(vm, filename, module, program);
         return fn;
     }
 
@@ -91,13 +91,13 @@ static void tryNativeLib(JStarVM* vm, JStarBuffer* modulePath, ObjString* module
 }
 
 static bool importWithSource(JStarVM* vm, const char* path, ObjString* name, const char* source) {
-    Stmt* program = parse(path, source);
+    Stmt* program = parse(path, source, vm->errorFun);
 
     if(program == NULL) {
         return false;
     }
 
-    ObjFunction* moduleFun = compileWithModule(vm, name, program);
+    ObjFunction* moduleFun = compileWithModule(vm, path, name, program);
     freeStmt(program);
 
     if(moduleFun == NULL) {

--- a/jstar/src/import.h
+++ b/jstar/src/import.h
@@ -10,7 +10,7 @@
 
 #define MAX_IMPORT_PATH_LEN 2048
 
-ObjFunction* compileWithModule(JStarVM* vm, ObjString* name, Stmt* program);
+ObjFunction* compileWithModule(JStarVM* vm, const char* filename, ObjString* name, Stmt* program);
 void setModule(JStarVM* vm, ObjString* name, ObjModule* module);
 ObjModule* getModule(JStarVM* vm, ObjString* name);
 bool importModule(JStarVM* vm, ObjString* name);

--- a/jstar/src/jsrparse/parser.c
+++ b/jstar/src/jsrparse/parser.c
@@ -15,17 +15,19 @@
 typedef struct Parser {
     Lexer lex;
     Token peek;
-    const char* fname;
+    const char* path;
     TokenType prevType;
     const char* lnStart;
+    ParseErrorFun errorFun;
     bool panic, hadError;
 } Parser;
 
-static void initParser(Parser* p, const char* fname, const char* src) {
+static void initParser(Parser* p, const char* path, const char* src, ParseErrorFun errorFun) {
     p->panic = false;
     p->hadError = false;
-    p->fname = fname;
+    p->path = path;
     p->prevType = -1;
+    p->errorFun = errorFun;
     initLexer(&p->lex, src);
     nextToken(&p->lex, &p->peek);
     p->lnStart = p->peek.lexeme;
@@ -42,30 +44,33 @@ static void error(Parser* p, const char* msg, ...) {
     if(p->panic) return;
     p->panic = p->hadError = true;
 
-    if(p->fname != NULL) {
-        fprintf(stderr, "File %s [line:%d]:\n", p->fname, p->peek.line);
+    if(p->errorFun) {
+        char errorMessage[MAX_ERR];
 
         // correct for escaped newlines
         const char* actualLnStart = p->lnStart;
-        while((actualLnStart = strchr(actualLnStart, '\n')) && actualLnStart < p->peek.lexeme)
+        while((actualLnStart = strchr(actualLnStart, '\n')) && actualLnStart < p->peek.lexeme) {
             p->lnStart = ++actualLnStart;
+        }
 
         int tokCol = (int)((p->peek.lexeme) - p->lnStart);
         int lineLen = (int)(strchrnul(p->peek.lexeme, '\n') - p->lnStart);
 
         // print source code snippet of the token near the error
-        fprintf(stderr, "    %.*s\n", lineLen, p->lnStart);
-        fprintf(stderr, "    ");
+        int len = 0;
+        len += snprintf(errorMessage + len, MAX_ERR - len, "    %.*s\n", lineLen, p->lnStart);
+        len += snprintf(errorMessage + len, MAX_ERR - len, "    ");
         for(int i = 0; i < tokCol; i++) {
-            fprintf(stderr, " ");
+            len += snprintf(errorMessage + len, MAX_ERR - len, " ");
         }
-        fprintf(stderr, "^\n");
+        len += snprintf(errorMessage + len, MAX_ERR - len, "^\n");
 
         va_list args;
         va_start(args, msg);
-        vfprintf(stderr, msg, args);
+        vsnprintf(errorMessage + len, MAX_ERR - len, msg, args);
         va_end(args);
-        fprintf(stderr, "\n");
+
+        p->errorFun(p->path, p->peek.line, errorMessage);
     }
 }
 
@@ -172,9 +177,9 @@ static void requireStmtEnd(Parser* p) {
 static Stmt* parseProgram(Parser* p);
 static Expr* expression(Parser* p, bool tuple);
 
-Stmt* parse(const char* fname, const char* src) {
+Stmt* parse(const char* path, const char* src, ParseErrorFun errorFun) {
     Parser p;
-    initParser(&p, fname, src);
+    initParser(&p, path, src, errorFun);
 
     Stmt* program = parseProgram(&p);
     skipNewLines(&p);
@@ -189,9 +194,9 @@ Stmt* parse(const char* fname, const char* src) {
     return program;
 }
 
-Expr* parseExpression(const char* fname, const char* src) {
+Expr* parseExpression(const char* path, const char* src, ParseErrorFun errorFun) {
     Parser p;
-    initParser(&p, fname, src);
+    initParser(&p, path, src, errorFun);
 
     Expr* expr = expression(&p, true);
     skipNewLines(&p);
@@ -542,23 +547,23 @@ static Stmt* funcDecl(Parser* p) {
         return NULL;
     }
 
-    Token fname = require(p, TOK_IDENTIFIER);
+    Token funcName = require(p, TOK_IDENTIFIER);
     FormalArgs args = formalArgs(p, TOK_LPAREN, TOK_RPAREN);
     Stmt* body = blockStmt(p);
     require(p, TOK_END);
 
-    return newFuncDecl(line, args.isVararg, &fname, args.arguments, args.defaults, body);
+    return newFuncDecl(line, args.isVararg, &funcName, args.arguments, args.defaults, body);
 }
 
 static Stmt* nativeDecl(Parser* p) {
     int line = p->peek.line;
     advance(p);
 
-    Token fname = require(p, TOK_IDENTIFIER);
+    Token funcName = require(p, TOK_IDENTIFIER);
     FormalArgs args = formalArgs(p, TOK_LPAREN, TOK_RPAREN);
     requireStmtEnd(p);
 
-    return newNativeDecl(line, args.isVararg, &fname, args.arguments, args.defaults);
+    return newNativeDecl(line, args.isVararg, &funcName, args.arguments, args.defaults);
 }
 
 static Stmt* classDecl(Parser* p) {

--- a/jstar/src/jstar.c
+++ b/jstar/src/jstar.c
@@ -32,7 +32,7 @@ void jsrInitConf(JStarConf* conf) {
     conf->stackSize = STACK_SZ;
     conf->initGC = INIT_GC;
     conf->heapGrowRate = HEAP_GROW_RATE;
-    conf->errorFun = &jsrPrintErrorCB;
+    conf->errorCallback = &jsrPrintErrorCB;
 }
 
 JStarResult jsrEvaluate(JStarVM* vm, const char* path, const char* src) {
@@ -40,7 +40,7 @@ JStarResult jsrEvaluate(JStarVM* vm, const char* path, const char* src) {
 }
 
 JStarResult jsrEvaluateModule(JStarVM* vm, const char* path, const char* module, const char* src) {
-    Stmt* program = parse(path, src, vm->errorFun);
+    Stmt* program = parse(path, src, vm->errorCallback);
     if(program == NULL) return JSR_SYNTAX_ERR;
 
     ObjString* name = copyString(vm, module, strlen(module), true);

--- a/jstar/src/jstar.c
+++ b/jstar/src/jstar.c
@@ -25,6 +25,19 @@
  * =========================================================
  */
 
+static void printError(JStarVM* vm, JStarResult errorCode, const char* file, int line,
+                       const char* error) {
+    fprintf(stderr, "File %s [line:%d]:\n", file, line);
+    fprintf(stderr, "%s\n", error);
+}
+
+void jsrInitConf(JStarConf* conf) {
+    conf->stackSize = STACK_SZ;
+    conf->initGC = INIT_GC;
+    conf->heapGrowRate = HEAP_GROW_RATE;
+    conf->errorFun = &printError;
+}
+
 JStarResult jsrEvaluate(JStarVM* vm, const char* fpath, const char* src) {
     return jsrEvaluateModule(vm, fpath, JSR_MAIN_MODULE, src);
 }

--- a/jstar/src/memory.c
+++ b/jstar/src/memory.c
@@ -383,7 +383,7 @@ void garbageCollect(JStarVM* vm) {
     vm->reachedCapacity = 0;
     vm->reachedCount = 0;
 
-    vm->nextGC = vm->allocated * HEAP_GROW_RATE;
+    vm->nextGC = vm->allocated * vm->heapGrowRate;
 
 #ifdef DBG_PRINT_GC
     size_t curr = prevAlloc - vm->allocated;

--- a/jstar/src/util.h
+++ b/jstar/src/util.h
@@ -23,4 +23,8 @@ static inline uint32_t hashString(const char* str, size_t length) {
     return hash;
 }
 
+static inline size_t roundUp(size_t num, size_t multiple) {
+    return ((num + multiple - 1) / multiple) * multiple;
+}
+
 #endif

--- a/jstar/src/vm.c
+++ b/jstar/src/vm.c
@@ -25,10 +25,6 @@ static void reset(JStarVM* vm) {
     vm->module = NULL;
 }
 
-static size_t roundUp(size_t num, size_t multiple) {
-    return ((num + multiple - 1) / multiple) * multiple;
-}
-
 JStarVM* jsrNewVM(JStarConf* conf) {
     JStarVM* vm = calloc(1, sizeof(*vm));
 
@@ -80,8 +76,8 @@ JStarVM* jsrNewVM(JStarConf* conf) {
     initCoreModule(vm);
 
     // Init main module
-    ObjString* mainModule = copyString(vm, JSR_MAIN_MODULE, strlen(JSR_MAIN_MODULE), true);
-    compileWithModule(vm, mainModule, NULL);
+    ObjString* mainModuleName = copyString(vm, JSR_MAIN_MODULE, strlen(JSR_MAIN_MODULE), true);
+    compileWithModule(vm, "<main>", mainModuleName, NULL);
 
     // This is called after initCoreLibrary in order to correctly assign
     // classes to objects, since classes are created in intCoreLibrary

--- a/jstar/src/vm.c
+++ b/jstar/src/vm.c
@@ -33,7 +33,7 @@ JStarVM* jsrNewVM(JStarConf* conf) {
     vm->stack = malloc(sizeof(Value) * vm->stackSz);
     vm->frames = malloc(sizeof(Frame) * vm->frameSz);
 
-    vm->errorFun = conf->errorFun;
+    vm->errorCallback = conf->errorCallback;
 
     reset(vm);
     initHashTable(&vm->modules);

--- a/jstar/src/vm.c
+++ b/jstar/src/vm.c
@@ -25,21 +25,27 @@ static void reset(JStarVM* vm) {
     vm->module = NULL;
 }
 
-JStarVM* jsrNewVM() {
+static size_t roundUp(size_t num, size_t multiple) {
+    return ((num + multiple - 1) / multiple) * multiple;
+}
+
+JStarVM* jsrNewVM(JStarConf* conf) {
     JStarVM* vm = calloc(1, sizeof(*vm));
 
-    vm->stackSz = STACK_SZ;
-    vm->frameSz = FRAME_SZ;
-    vm->stack = malloc(sizeof(Value) * STACK_SZ);
-    vm->frames = malloc(sizeof(Frame) * FRAME_SZ);
+    vm->stackSz = roundUp(conf->stackSize, MAX_LOCALS + 1);
+    vm->frameSz = vm->stackSz / (MAX_LOCALS + 1);
+    vm->stack = malloc(sizeof(Value) * vm->stackSz);
+    vm->frames = malloc(sizeof(Frame) * vm->frameSz);
+
+    vm->errorFun = conf->errorFun;
 
     reset(vm);
-
     initHashTable(&vm->modules);
     initHashTable(&vm->strings);
 
     // init GC
-    vm->nextGC = INIT_GC;
+    vm->nextGC = conf->initGC;
+    vm->heapGrowRate = conf->heapGrowRate;
 
     // Create constants strings
     vm->stacktrace = copyString(vm, EXC_M_STACKTRACE, strlen(EXC_M_STACKTRACE), true);
@@ -74,7 +80,8 @@ JStarVM* jsrNewVM() {
     initCoreModule(vm);
 
     // Init main module
-    compileWithModule(vm, copyString(vm, JSR_MAIN_MODULE, strlen(JSR_MAIN_MODULE), true), NULL);
+    ObjString* mainModule = copyString(vm, JSR_MAIN_MODULE, strlen(JSR_MAIN_MODULE), true);
+    compileWithModule(vm, mainModule, NULL);
 
     // This is called after initCoreLibrary in order to correctly assign
     // classes to objects, since classes are created in intCoreLibrary

--- a/jstar/src/vm.h
+++ b/jstar/src/vm.h
@@ -95,6 +95,9 @@ struct JStarVM {
     // Linked list of all open upvalues
     ObjUpvalue* upvalues;
 
+    // Callback function to report errors
+    JStarErrorFun errorFun;
+
     // ---- Memory management ----
 
     // Linked list of all allocated objects (used in
@@ -104,6 +107,7 @@ struct JStarVM {
     bool disableGC;    // Whether the garbage collector is enabled or disabled
     size_t allocated;  // Bytes currently allocated
     size_t nextGC;     // Bytes to which the next GC will be triggered
+    int heapGrowRate;  // Rate at which the heaap will grow after a GC
 
     // Stack used to recursevely reach all the fields of reached objects
     Obj** reachedStack;

--- a/jstar/src/vm.h
+++ b/jstar/src/vm.h
@@ -96,7 +96,7 @@ struct JStarVM {
     ObjUpvalue* upvalues;
 
     // Callback function to report errors
-    JStarErrorFun errorFun;
+    JStarErrorCB errorCallback;
 
     // ---- Memory management ----
 


### PR DESCRIPTION
Extended API:
 - Now jsrNewVM accepts an instance of JStarConf struct that enables the user to change
   starting stack size, inital garbage collection memory threshold and heap grow rate after GC.
  The user can also specify a 'JStarErrorCB' function that the vm will call in case of parsing and/or
  compiling errors.
- Added jsrInitConfig function that initializes the JStarConf struct to default values (these are the
 initial values that were previously hardcoded).
- Added jsrPrintErrorCB to the API. This is a default implementation of 'JStarErrorCB' that simply prints the error to stderr.
- Added the ability to specify a 'ParseErrorCB' when parsing using the 'parse' and 'parseExpression' functions in parse.h/c. This function has the same signature as 'JStarErrorCB' (in fact the vm passes its JStarErrorCB when it needs to parse some code) and it is called by the parser if it encounters syntax errors. The reason for a different typedef is to mantain the main vm code completely decoupled from parsing code.
