### PR TITLE
Eval break

### DIFF
--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,9 +26,15 @@ typedef struct CLIOpts {
     int argsCount;
 } CLIOpts;
 
+static void breakEval(int signal) {
+    printf("Keyboard signal received!\n");
+    jsrEvalBreak(vm);
+}
+
 static void initVM(void) {
     JStarConf conf = jsrGetConf();
     vm = jsrNewVM(&conf);
+    signal(SIGINT, &breakEval);
 }
 
 static void exitFree(int code) {
@@ -222,10 +229,12 @@ static CLIOpts parseArguments(int argc, const char** argv) {
     if(nonOptsCount > 0) {
         opts.script = argv[0];
     }
+
     if(nonOptsCount > 1) {
         opts.args = &argv[1];
         opts.argsCount = nonOptsCount - 1;
     }
+
     return opts;
 }
 

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -76,7 +76,7 @@ static void sigintHandler(int sig) {
     jsrEvalBreak(vm);
 }
 
-static JStarResult evaluateScript(const char* name, const char* src) {
+static JStarResult evaluate(const char* name, const char* src) {
     signal(SIGINT, &sigintHandler);
     JStarResult res = jsrEvaluate(vm, name, src);
     signal(SIGINT, SIG_DFL);
@@ -169,7 +169,7 @@ static void doRepl(CLIOpts* opts) {
         }
 
         addPrintIfExpr(&src);
-        res = evaluateScript("<stdin>", src.data);
+        res = evaluate("<stdin>", src.data);
         jsrBufferClear(&src);
     }
 
@@ -204,7 +204,7 @@ static JStarResult execScript(const char* script, int argc, const char** args, b
         exitFree(EXIT_FAILURE);
     }
 
-    JStarResult res = evaluateScript(script, src);
+    JStarResult res = evaluate(script, src);
     free(src);
 
     return res;

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -11,9 +11,12 @@
 #include "jstar/parse/parser.h"
 #include "linenoise.h"
 
-#define JSTARPATH "JSTARPATH"
+#define JSTAR_PATH   "JSTARPATH"
+#define JSTAR_PROMPT "J*>> "
+#define LINE_PROMPT  ".... "
 
 static JStarVM* vm;
+static JStarBuffer completionBuf;
 
 typedef struct CLIOpts {
     const char* script;
@@ -26,45 +29,26 @@ typedef struct CLIOpts {
     int argsCount;
 } CLIOpts;
 
-static void breakEval(int sig) {
-    jsrEvalBreak(vm);
-
-#ifdef JSTAR_WINDOWS
-    signal(SIGINT, &breakEval);
-#endif
-}
-
 static void initVM(void) {
     JStarConf conf = jsrGetConf();
     vm = jsrNewVM(&conf);
-    signal(SIGINT, &breakEval);
+    jsrBufferInit(vm, &completionBuf);
 }
 
 static void exitFree(int code) {
+    jsrBufferFree(&completionBuf);
     jsrFreeVM(vm);
     exit(code);
 }
 
 // -----------------------------------------------------------------------------
-// REPL
+// UTILITY FUNCTIONS
 // -----------------------------------------------------------------------------
-
-static void printVersion(void) {
-    printf("J* Version %s\n", JSTAR_VERSION_STRING);
-    printf("%s on %s\n", JSTAR_COMPILER, JSTAR_PLATFORM);
-}
-
-// Little hack to enable adding a tab in linenoise
-static void completion(const char* buf, linenoiseCompletions* lc) {
-    char indented[1024];
-    snprintf(indented, sizeof(indented), "%s    ", buf);
-    linenoiseAddCompletion(lc, indented);
-}
 
 static void initImportPaths(const char* path, bool ignoreEnv) {
     jsrAddImportPath(vm, path);
     if(!ignoreEnv) {
-        const char* jstarPath = getenv(JSTARPATH);
+        const char* jstarPath = getenv(JSTAR_PATH);
         if(jstarPath == NULL) return;
 
         JStarBuffer buf;
@@ -85,6 +69,35 @@ static void initImportPaths(const char* path, bool ignoreEnv) {
         jsrAddImportPath(vm, buf.data);
         jsrBufferFree(&buf);
     }
+}
+
+static void sigintHandler(int sig) {
+    signal(sig, SIG_DFL);
+    jsrEvalBreak(vm);
+}
+
+static JStarResult evaluateScript(const char* name, const char* src) {
+    signal(SIGINT, &sigintHandler);
+    JStarResult res = jsrEvaluate(vm, name, src);
+    signal(SIGINT, SIG_DFL);
+    return res;
+}
+
+// -----------------------------------------------------------------------------
+// REPL
+// -----------------------------------------------------------------------------
+
+static void printVersion(void) {
+    printf("J* Version %s\n", JSTAR_VERSION_STRING);
+    printf("%s on %s\n", JSTAR_COMPILER, JSTAR_PLATFORM);
+}
+
+// Little hack to enable adding a tab in the REPL.
+// Simply add 4 spaces on linenoise tab completion.
+static void completion(const char* buf, linenoiseCompletions* lc) {
+    jsrBufferClear(&completionBuf);
+    jsrBufferAppendf(&completionBuf, "%s    ", buf);
+    linenoiseAddCompletion(lc, completionBuf.data);
 }
 
 static int countBlocks(const char* line) {
@@ -138,38 +151,39 @@ static void doRepl(CLIOpts* opts) {
 
     JStarBuffer src;
     jsrBufferInit(vm, &src);
+    JStarResult res = JSR_EVAL_SUCCESS;
 
     char* line;
-    while((line = linenoise("J*>> ")) != NULL) {
+    while((line = linenoise(JSTAR_PROMPT)) != NULL) {
         linenoiseHistoryAdd(line);
         int depth = countBlocks(line);
         jsrBufferAppendstr(&src, line);
         free(line);
 
-        while(depth > 0 && (line = linenoise(".... ")) != NULL) {
+        while(depth > 0 && (line = linenoise(LINE_PROMPT)) != NULL) {
             linenoiseHistoryAdd(line);
-            jsrBufferAppendChar(&src, '\n');
             depth += countBlocks(line);
+            jsrBufferAppendChar(&src, '\n');
             jsrBufferAppendstr(&src, line);
             free(line);
         }
 
         addPrintIfExpr(&src);
-        jsrEvaluate(vm, "<stdin>", src.data);
+        res = evaluateScript("<stdin>", src.data);
         jsrBufferClear(&src);
     }
 
     jsrBufferFree(&src);
     linenoiseHistoryFree();
+    exitFree(res);
 }
 
 // -----------------------------------------------------------------------------
 // SCRIPT EXECUTION
 // -----------------------------------------------------------------------------
 
-static JStarResult execScript(const char* script, int argsCount, const char** args,
-                              bool ignoreEnv) {
-    jsrInitCommandLineArgs(vm, argsCount, args);
+static JStarResult execScript(const char* script, int argc, const char** args, bool ignoreEnv) {
+    jsrInitCommandLineArgs(vm, argc, args);
 
     // set base import path to script's directory
     char* directory = strrchr(script, '/');
@@ -190,8 +204,9 @@ static JStarResult execScript(const char* script, int argsCount, const char** ar
         exitFree(EXIT_FAILURE);
     }
 
-    JStarResult res = jsrEvaluate(vm, script, src);
+    JStarResult res = evaluateScript(script, src);
     free(src);
+
     return res;
 }
 
@@ -243,12 +258,13 @@ static CLIOpts parseArguments(int argc, const char** argv) {
 
 int main(int argc, const char** argv) {
     CLIOpts opts = parseArguments(argc, argv);
-    initVM();
 
     if(opts.showVersion) {
         printVersion();
-        exitFree(EXIT_SUCCESS);
+        exit(EXIT_SUCCESS);
     }
+
+    initVM();
 
     if(opts.execStmt) {
         JStarResult res = jsrEvaluate(vm, "<string>", opts.execStmt);
@@ -262,5 +278,4 @@ int main(int argc, const char** argv) {
     }
 
     doRepl(&opts);
-    exitFree(EXIT_SUCCESS);
 }

--- a/cli/src/cli.c
+++ b/cli/src/cli.c
@@ -26,9 +26,12 @@ typedef struct CLIOpts {
     int argsCount;
 } CLIOpts;
 
-static void breakEval(int signal) {
-    printf("Keyboard signal received!\n");
+static void breakEval(int sig) {
     jsrEvalBreak(vm);
+
+#ifdef JSTAR_WINDOWS
+    signal(SIGINT, &breakEval);
+#endif
 }
 
 static void initVM(void) {

--- a/jstar/include/jstar/jstar.h
+++ b/jstar/include/jstar/jstar.h
@@ -95,6 +95,9 @@ JSTAR_API JStarResult jsrEvaluateModule(JStarVM* vm, const char* path, const cha
 JSTAR_API JStarResult jsrCall(JStarVM* vm, uint8_t argc);
 JSTAR_API JStarResult jsrCallMethod(JStarVM* vm, const char* name, uint8_t argc);
 
+// Breaks J* evaluation at the first chance possible.
+// It can be called by an asynchronous signal handler.
+JSTAR_API void jsrEvalBreak(JStarVM* vm);
 // Prints the the stacktrace of the exception at slot 'slot'. If the value at 'slot' is not an
 // Exception, or is a non-yet-raised Exception, it doesn't print anything ad returns successfully
 JSTAR_API void jsrPrintStacktrace(JStarVM* vm, int slot);

--- a/jstar/src/code.c
+++ b/jstar/src/code.c
@@ -2,6 +2,8 @@
 
 #include <stdbool.h>
 
+#include "util.h"
+
 #define CODE_DEF_SIZE  8
 #define CODE_GROW_FACT 2
 
@@ -54,6 +56,7 @@ size_t writeByte(Code* c, uint8_t b, int line) {
 }
 
 int getBytecodeSrcLine(Code* c, size_t index) {
+    ASSERT(index < c->linesCount, "Line buffer overflow");
     return c->lines[index];
 }
 

--- a/jstar/src/compiler.c
+++ b/jstar/src/compiler.c
@@ -287,8 +287,8 @@ static size_t emitJumpTo(Compiler* c, int jmpOpcode, size_t target, int line) {
     if(offset > INT16_MAX || offset < INT16_MIN) {
         error(c, line, "Too much code to jump over.");
     }
-    emitBytecode(c, jmpOpcode, 0);
-    emitShort(c, (uint16_t)offset, 0);
+    emitBytecode(c, jmpOpcode, line);
+    emitShort(c, (uint16_t)offset, line);
     return c->func->code.count - 2;
 }
 
@@ -987,7 +987,7 @@ static void compileForStatement(Compiler* c, JStarStmt* s) {
 
     size_t firstJmp = 0;
     if(s->as.forStmt.act != NULL) {
-        firstJmp = emitBytecode(c, OP_JUMP, s->line);
+        firstJmp = emitBytecode(c, OP_JUMP, 0);
         emitShort(c, 0, 0);
     }
 
@@ -997,7 +997,7 @@ static void compileForStatement(Compiler* c, JStarStmt* s) {
     if(s->as.forStmt.act != NULL) {
         compileExpr(c, s->as.forStmt.act);
         emitBytecode(c, OP_POP, 0);
-        setJumpTo(c, firstJmp, c->func->code.count, s->line);
+        setJumpTo(c, firstJmp, c->func->code.count, 0);
     }
 
     size_t exitJmp = 0;
@@ -1008,10 +1008,10 @@ static void compileForStatement(Compiler* c, JStarStmt* s) {
     }
 
     compileStatement(c, s->as.forStmt.body);
-    emitJumpTo(c, OP_JUMP, l.start, 0);
+    emitJumpTo(c, OP_JUMP, l.start, s->line);
 
     if(s->as.forStmt.cond != NULL) {
-        setJumpTo(c, exitJmp, c->func->code.count, s->line);
+        setJumpTo(c, exitJmp, c->func->code.count, 0);
     }
 
     endLoop(c);
@@ -1076,7 +1076,7 @@ static void compileForEach(Compiler* c, JStarStmt* s) {
 
     exitScope(c);
 
-    emitJumpTo(c, OP_JUMP, l.start, 0);
+    emitJumpTo(c, OP_JUMP, l.start, s->line);
     setJumpTo(c, exitJmp, c->func->code.count, s->line);
 
     endLoop(c);
@@ -1093,7 +1093,7 @@ static void compileWhileStatement(Compiler* c, JStarStmt* s) {
 
     compileStatement(c, s->as.whileStmt.body);
 
-    emitJumpTo(c, OP_JUMP, l.start, 0);
+    emitJumpTo(c, OP_JUMP, l.start, s->line);
     setJumpTo(c, exitJmp, c->func->code.count, s->line);
 
     endLoop(c);

--- a/jstar/src/jstar.c
+++ b/jstar/src/jstar.c
@@ -110,6 +110,10 @@ JStarResult jsrCallMethod(JStarVM* vm, const char* name, uint8_t argc) {
     return finishCall(vm, depth, offsp);
 }
 
+void jsrEvalBreak(JStarVM* vm) {
+    if(vm->frameCount) vm->evalBreak = 1;
+}
+
 void jsrPrintStacktrace(JStarVM* vm, int slot) {
     Value exc = vm->apiStack[apiStackIndex(vm, slot)];
     ASSERT(isInstance(vm, exc, vm->excClass), "Top of stack isn't an exception");

--- a/jstar/src/object.c
+++ b/jstar/src/object.c
@@ -155,6 +155,8 @@ void stRecordFrame(JStarVM* vm, ObjStackTrace* st, Frame* f, int depth) {
         ObjFunction* fn = ((ObjClosure*)f->fn)->fn;
         Code* code = &fn->code;
         size_t op = f->ip - code->bytecode - 1;
+        op = op < code->count ? op : code->count - 1;
+
         record->line = getBytecodeSrcLine(code, op);
         record->moduleName = fn->c.module->name;
         record->funcName = fn->c.name;

--- a/jstar/src/std/core.jsr
+++ b/jstar/src/std/core.jsr
@@ -437,3 +437,4 @@ class InvalidArgException is Exception end
 class IndexOutOfBoundException is Exception end
 class AssertException is Exception end
 class NotImplementedException is Exception end
+class ProgramInterrupt is Exception end

--- a/jstar/src/std/core.jsr.h
+++ b/jstar/src/std/core.jsr.h
@@ -375,4 +375,5 @@ const char *core_jsr =
 "class IndexOutOfBoundException is Exception end\n"
 "class AssertException is Exception end\n"
 "class NotImplementedException is Exception end\n"
+"class ProgramInterrupt is Exception end\n"
 ;

--- a/jstar/src/vm.c
+++ b/jstar/src/vm.c
@@ -792,13 +792,13 @@ bool runEval(JStarVM* vm, int depth) {
         DISPATCH();                   \
     } while(0)
 
-#define CHECK_EVAL_BREAK(vm)                      \
-    do {                                          \
-        if(vm->evalBreak) {                       \
-            vm->evalBreak = 0;                    \
-            jsrRaise(vm, "ProgramInterrupt", ""); \
-            UNWIND_STACK(vm);                     \
-        }                                         \
+#define CHECK_EVAL_BREAK(vm)                        \
+    do {                                            \
+        if(vm->evalBreak) {                         \
+            vm->evalBreak = 0;                      \
+            jsrRaise(vm, "ProgramInterrupt", NULL); \
+            UNWIND_STACK(vm);                       \
+        }                                           \
     } while(0)
 
 #ifdef JSTAR_DBG_PRINT_EXEC
@@ -987,9 +987,9 @@ bool runEval(JStarVM* vm, int depth) {
     }
 
     TARGET(OP_JUMP): {
-        CHECK_EVAL_BREAK(vm);
         int16_t off = NEXT_SHORT();
         ip += off;
+        CHECK_EVAL_BREAK(vm);
         DISPATCH();
     }
 
@@ -1141,6 +1141,7 @@ sup_invoke:;
 op_return:
     TARGET(OP_RETURN): {
         Value ret = pop(vm);
+        CHECK_EVAL_BREAK(vm);
 
         while(frame->handlerc > 0) {
             Handler* h = &frame->handlers[--frame->handlerc];
@@ -1162,7 +1163,6 @@ op_return:
         LOAD_STATE();
         vm->module = fn->c.module;
 
-        CHECK_EVAL_BREAK(vm);
         DISPATCH();
     }
 

--- a/jstar/src/vm.h
+++ b/jstar/src/vm.h
@@ -11,6 +11,7 @@
 #include "jstar.h"
 #include "object.h"
 #include "opcode.h"
+#include "signal.h"
 #include "util.h"
 #include "value.h"
 
@@ -124,6 +125,9 @@ struct JStarVM {
 
     // Callback function to report errors
     JStarErrorCB errorCallback;
+
+    // If set, the VM will break the eval loop as soon as possible
+    sig_atomic_t evalBreak;
 
     // ---- Memory management ----
 

--- a/jstar/src/vm.h
+++ b/jstar/src/vm.h
@@ -126,8 +126,9 @@ struct JStarVM {
     // Callback function to report errors
     JStarErrorCB errorCallback;
 
-    // If set, the VM will break the eval loop as soon as possible
-    sig_atomic_t evalBreak;
+    // If set, the VM will break the eval loop as soon as possible.
+    // Can be set asynchronously by a signal handler
+    volatile sig_atomic_t evalBreak;
 
     // ---- Memory management ----
 


### PR DESCRIPTION
Implemented a way to break evaluation of code using asynchronous signal handlers.
Now the cli app registers a sigint signal handler and calls the async-safe function jsrEvalBreak that sets a volatile signal-atomic flag called 'evalBreak' inside the JStarVM struct.
During the main loop in 'runEval', the vm checks for this flag during OP_RETURN and OP_JUMP opcodes and raises a ProgramInterrupt exception if it is found set. Checking only these two opcodes is sufficient to break out of the mainloop in every situation, since the code will eventually return from a function or, if it doesn't, it means it is executing a loop (that ends with an OP_JUMP). The assumption here is that typical code calls (and in turn returns from) functions fairly often, the only exception being a long running (or infinite) loop, so the time between the setting of evalBreak and the raising of ProgramInterrupt should be faily small even if we do not check for the flag on every opcode, thus saving on performace.