### PR TITLE
Restrict types of expression statements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,6 @@
 {
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
     "cmake.buildDirectory": "${workspaceFolder}/build/${buildType}",
-    "editor.formatOnSave": true,
     "files.associations": {
         "jstar.h": "c",
         "limits": "c",
@@ -84,5 +83,6 @@
         "typeinfo": "cpp",
         "valarray": "cpp",
         "variant": "cpp"
-    }
+    },
+    "editor.formatOnSave": true
 }


### PR DESCRIPTION
Not all expressions can now be expression statements.
Specifically, only variable assignments or function calls can appear as statements.
This somewhat simplifies the implementation of the parser, that now doesn't require a peek distance greater than one to distinguish between anonymous function statements and regular ones, since the former can no longer exist.
As a plus, expression statements that do not have side effects are now syntactically disallowed, preventing the compilation of programs that immediately discard results of expressions (i.e. perform useless computations).