### PR TITLE
Added `static` declarations to the language

### DIFF
--- a/include/jstar/parse/ast.h
+++ b/include/jstar/parse/ast.h
@@ -159,6 +159,7 @@ struct JStarStmt {
         } blockStmt;
         struct {
             bool isUnpack;
+            bool isStatic;
             Vector ids;
             JStarExpr* init;
         } varDecl;
@@ -166,14 +167,17 @@ struct JStarStmt {
             JStarIdentifier id;
             Vector formalArgs, defArgs;
             bool isVararg;
+            bool isStatic;
             JStarStmt* body;
         } funcDecl;
         struct {
             JStarIdentifier id;
             Vector formalArgs, defArgs;
             bool isVararg;
+            bool isStatic;
         } nativeDecl;
         struct {
+            bool isStatic;
             JStarIdentifier id;
             JStarExpr* sup;
             Vector methods;

--- a/include/jstar/parse/token.def
+++ b/include/jstar/parse/token.def
@@ -69,6 +69,7 @@ TOKEN(TOK_VAR, "var")
 TOKEN(TOK_WHILE, "while")
 TOKEN(TOK_CONTINUE, "continue")
 TOKEN(TOK_BREAK, "break")
+TOKEN(TOK_STATIC, "static")
 
 TOKEN(TOK_TRY, "try")
 TOKEN(TOK_EXCEPT, "except")

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -311,6 +311,7 @@ static size_t emitJumpTo(Compiler* c, int jmpOpcode, size_t target, int line) {
     if(offset > INT16_MAX || offset < INT16_MIN) {
         error(c, line, "Too much code to jump over.");
     }
+
     emitBytecode(c, jmpOpcode, line);
     emitShort(c, (uint16_t)offset, line);
     return getCurrentAddr(c) - 2;
@@ -321,6 +322,7 @@ static void setJumpTo(Compiler* c, size_t jumpAddr, size_t target, int line) {
     if(offset > INT16_MAX || offset < INT16_MIN) {
         error(c, line, "Too much code to jump over.");
     }
+
     Code* code = &c->func->code;
     code->bytecode[jumpAddr + 1] = (uint8_t)((uint16_t)offset >> 8);
     code->bytecode[jumpAddr + 2] = (uint8_t)((uint16_t)offset);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -274,7 +274,7 @@ static int declareVar(Compiler* c, JStarIdentifier* id, bool forceLocal, int lin
     if(inGlobalScope(c) && !forceLocal) return -1;
 
     if(!inGlobalScope(c) && forceLocal) {
-        error(c, line, "static declaration can appear only in global scope.");
+        error(c, line, "static declaration can only appear in global scope.");
         return -1;
     }
 
@@ -292,8 +292,9 @@ static int declareVar(Compiler* c, JStarIdentifier* id, bool forceLocal, int lin
 static void markInitialized(Compiler* c, int idx, bool forceLocal) {
     if(c->depth == 0 && !forceLocal) return;
 
-    ASSERT(idx >= 0 && idx < c->localsCount, "Invalid local variable");
-    c->locals[idx].depth = c->depth;
+    if(idx >= 0) {
+        c->locals[idx].depth = c->depth;
+    }
 }
 
 static void defineVar(Compiler* c, JStarIdentifier* id, int idx, bool forceLocal, int line) {

--- a/src/parse/ast.c
+++ b/src/parse/ast.c
@@ -255,6 +255,7 @@ JStarStmt* jsrFuncDecl(int line, JStarTok* name, Vector* args, Vector* defArgs, 
     f->as.funcDecl.formalArgs = vecMove(args);
     f->as.funcDecl.defArgs = vecMove(defArgs);
     f->as.funcDecl.isVararg = vararg;
+    f->as.funcDecl.isStatic = false;
     f->as.funcDecl.body = body;
     return f;
 }
@@ -265,6 +266,7 @@ JStarStmt* jsrNativeDecl(int line, JStarTok* name, Vector* args, Vector* defArgs
     n->as.nativeDecl.id.length = name->length;
     n->as.nativeDecl.formalArgs = vecMove(args);
     n->as.nativeDecl.isVararg = vararg;
+    n->as.nativeDecl.isStatic = false;
     n->as.nativeDecl.defArgs = vecMove(defArgs);
     return n;
 }
@@ -272,10 +274,20 @@ JStarStmt* jsrNativeDecl(int line, JStarTok* name, Vector* args, Vector* defArgs
 JStarStmt* jsrClassDecl(int line, JStarTok* clsName, JStarExpr* sup, Vector* methods) {
     JStarStmt* c = newStmt(line, JSR_CLASSDECL);
     c->as.classDecl.sup = sup;
+    c->as.classDecl.isStatic = false;
     c->as.classDecl.id.name = clsName->lexeme;
     c->as.classDecl.id.length = clsName->length;
     c->as.classDecl.methods = vecMove(methods);
     return c;
+}
+
+JStarStmt* jsrVarDecl(int line, bool isUnpack, Vector* ids, JStarExpr* init) {
+    JStarStmt* s = newStmt(line, JSR_VARDECL);
+    s->as.varDecl.ids = vecMove(ids);
+    s->as.varDecl.isUnpack = isUnpack;
+    s->as.varDecl.isStatic = false;
+    s->as.varDecl.init = init;
+    return s;
 }
 
 JStarStmt* jsrWithStmt(int line, JStarExpr* e, JStarTok* varName, JStarStmt* block) {
@@ -301,14 +313,6 @@ JStarStmt* jsrForEachStmt(int line, JStarStmt* var, JStarExpr* iter, JStarStmt* 
     s->as.forEach.var = var;
     s->as.forEach.iterable = iter;
     s->as.forEach.body = body;
-    return s;
-}
-
-JStarStmt* jsrVarDecl(int line, bool isUnpack, Vector* ids, JStarExpr* init) {
-    JStarStmt* s = newStmt(line, JSR_VARDECL);
-    s->as.varDecl.ids = vecMove(ids);
-    s->as.varDecl.isUnpack = isUnpack;
-    s->as.varDecl.init = init;
     return s;
 }
 

--- a/src/parse/lex.c
+++ b/src/parse/lex.c
@@ -49,6 +49,7 @@ static Keyword keywords[] = {
     {"with",     4, TOK_WITH},
     {"continue", 8, TOK_CONTINUE},
     {"break",    5, TOK_BREAK},
+    {"static",   6, TOK_STATIC},
     // sentinel
     {NULL,       0, TOK_EOF}
 };

--- a/src/parse/parser.c
+++ b/src/parse/parser.c
@@ -742,7 +742,7 @@ static JStarStmt* exprStmt(Parser* p) {
     JStarExpr* l = tupleLiteral(p);
 
     if(!isAssign(&p->peek) && !isCallExpression(l)) {
-        error(p, "Syntax error.");
+        error(p, "Syntax error");
     }
 
     if(isAssign(&p->peek)) {

--- a/src/std/io.h
+++ b/src/std/io.h
@@ -19,13 +19,13 @@ JSR_NATIVE(jsr_File_rewind);
 JSR_NATIVE(jsr_File_flush);
 // } class File
 
-// class __PFile {
-JSR_NATIVE(jsr_PFile_close);
+// class Popen {
+JSR_NATIVE(jsr_Popen_new);
+JSR_NATIVE(jsr_Popen_close);
 // }
 
 // prototypes
 
-JSR_NATIVE(jsr_popen);
 JSR_NATIVE(jsr_remove);
 JSR_NATIVE(jsr_rename);
 JSR_NATIVE(jsr_io_init);

--- a/src/std/io.jsr
+++ b/src/std/io.jsr
@@ -43,16 +43,15 @@ class File
     end
 end
 
-class __PFile is File
-    fun new(handle)
-        this._handle = handle
-        this._closed = false
-    end
-
+static class Popen is File
+    native new(name, mode)
     native close()
 end
 
-native popen(name, mode="r")
+fun popen(name, mode="r")
+    return Popen(name, mode)
+end
+
 native remove(path)
 native rename(oldpath, newpath)
 

--- a/src/std/io.jsr
+++ b/src/std/io.jsr
@@ -56,7 +56,5 @@ native popen(name, mode="r")
 native remove(path)
 native rename(oldpath, newpath)
 
-begin
-    native init()
-    init()
-end
+static native init()
+init()

--- a/src/std/math.jsr
+++ b/src/std/math.jsr
@@ -41,7 +41,5 @@ fun randint(a, b=null)
     return int(a + random() * (b - a + 1))
 end
 
-begin
-    native init()
-    init()
-end
+static native init()
+init()

--- a/src/std/modules.c
+++ b/src/std/modules.c
@@ -188,10 +188,10 @@ Module builtInModules[] = {
             METHOD(rewind,   jsr_File_rewind)
             METHOD(flush,    jsr_File_flush)
         ENDCLASS
-        CLASS(__PFile)
-            METHOD(close, jsr_PFile_close)
+        CLASS(Popen)
+            METHOD(new,   jsr_Popen_new)
+            METHOD(close, jsr_Popen_close)
         ENDCLASS
-        FUNCTION(popen,  jsr_popen)
         FUNCTION(remove, jsr_remove)
         FUNCTION(rename, jsr_rename)
         FUNCTION(init,   jsr_io_init)

--- a/src/std/re.jsr
+++ b/src/std/re.jsr
@@ -5,7 +5,7 @@ native find(str, regex, off=0)
 native gsub(str, regex, sub, num=0)
 native gmatch(str, regex)
 
-class igmatch
+static class IGmatch is Iter
     fun new(str, regex)
         this.s, this.r = str, regex
         this.off, this.endl = 0, null
@@ -20,13 +20,16 @@ class igmatch
         var b, e = res
         while e == this.endl and e - b == 0 do
             res = find(this.s, this.r, this.off += 1)
-            if res then return null end
+            if !res then 
+                return null
+            end
             b, e = res
         end
 
         var resLen = #res
         this.off = this.endl = e
-        if   resLen == 2 then
+        
+        if resLen == 2 then
             return this.s[b, e]
         elif resLen == 3 then
             return res[2]
@@ -38,4 +41,8 @@ class igmatch
     fun __next__(match)
         return match
     end
+end
+
+fun igmatch(str, regex)
+    return IGmatch(str, regex)
 end

--- a/src/std/sys.c
+++ b/src/std/sys.c
@@ -89,8 +89,8 @@ JSR_NATIVE(jsr_exec) {
         jsrBufferFree(&data);
         JSR_RAISE(vm, "Exception", strerror(errno));
     } else {
-        jsrPushNumber(vm, pclose(proc));
         jsrBufferPush(&data);
+        jsrPushNumber(vm, pclose(proc));
         jsrPushTuple(vm, 2);
     }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -4,6 +4,7 @@
 #include <string.h>
 
 #include "code.h"
+#include "disassemble.h"
 #include "gc.h"
 #include "import.h"
 #include "opcode.h"


### PR DESCRIPTION
A `static` declaration works conceptually similarly to a C static variable or function.
When used to annotate a global variable, function, native or class declaration that declaration is private to the module and can't be accessed by clients importing it.
For example:
```lua
-- file private.jsr

static var globalVar = "Private Var"

static class PrivateClass
    fun new(someData)
        this.data = someData
    end
end

fun makePrivate(someData)
    return PrivateClass(someData)
end

fun getGlobalVar()
    return globalVar
end
```
A file `client.jsr` cannot access directly globalVar or PrivateClass, but has to use the non `static` functions `makePrivate` or `getGlobalVar`.
```lua
-- flie client.jsr

import private

private.PrivateClass("data") -- This will result in a NameException, as client cannot find PrivateClass in private
private.makePrivate("data")  -- This will succeed instead
```
Note: `static` declarations are implemented using upvalues and the usual J* scoping rules. This means that, for reasons dictated by the scoping, `static` declarations must appear before their use (as opposed to 'normal' global variables), otherwise the compiler can't bind the right variable to the point of usage, and will fallback to look for a non `static` global variable, failing in finding it.  

The previous paragraph makes it clear that `static` declarations are actually just syntactic sugar to ease the declaration of module-private functions, classes, natives or variables. An equivalent way to implement `private.jsr` prior the introduction of `static` would be:
```lua
-- private.jsr without static

var makePrivate, getGlobalVar -- Create global variables for externally accessible functions

begin -- Start a local scope

    -- globalVar and PrivateFunction are local to the scope, and will be unreachable when it ends
    var globalVar = "Private Var"

    class PrivateClass
        fun new(someData)
            this.data = someData
        end
    end

    -- Set makeFunction to a function that instantiates and returns `PrivateClass`.
    -- Thanks to lexical scope rules `PrivateClass` will bind to the local declaration, 
    -- and it will remain available to the function even when the scope ends
    makePrivate = fun(someData)
        return PrivateClass(someData)
    end

    -- Do the same thing for globalVar
    getGlobalVar = fun()
        return globalVar
    end

end
``` 
It is clear why the introduction of `static` makes this pattern better: less indentation, less lines of code and no need to use function literals and global variables together to make externally accessible functions.