### PR TITLE
Add the possibility of unpacking function arguments

### DIFF
--- a/apps/jstar/main.c
+++ b/apps/jstar/main.c
@@ -236,13 +236,10 @@ static void addReplPrint(JStarBuffer* sb) {
 static JStarResult doRepl(void) {
     PROFILE_BEGIN_SESSION("jstar-repl.json")
 
-
     JStarResult res = JSR_SUCCESS;
     {
         PROFILE_FUNC()
 
-        // Init empty main module
-        jsrEvalModuleString(vm, "<repl>", JSR_MAIN_MODULE, "");
         registerPrintFunction();
         
         if(!opts.skipVersion) {

--- a/include/jstar/conf.h
+++ b/include/jstar/conf.h
@@ -18,7 +18,7 @@
 // Options
 #define JSTAR_COMPUTED_GOTOS
 #define JSTAR_NAN_TAGGING
-/* #undef JSTAR_DBG_PRINT_EXEC */
+#define JSTAR_DBG_PRINT_EXEC
 /* #undef JSTAR_DBG_PRINT_GC */
 /* #undef JSTAR_DBG_STRESS_GC */
 

--- a/include/jstar/conf.h
+++ b/include/jstar/conf.h
@@ -18,7 +18,7 @@
 // Options
 #define JSTAR_COMPUTED_GOTOS
 #define JSTAR_NAN_TAGGING
-#define JSTAR_DBG_PRINT_EXEC
+/* #undef JSTAR_DBG_PRINT_EXEC */
 /* #undef JSTAR_DBG_PRINT_GC */
 /* #undef JSTAR_DBG_STRESS_GC */
 

--- a/include/jstar/parse/ast.h
+++ b/include/jstar/parse/ast.h
@@ -135,6 +135,17 @@ typedef enum JStarStmtType {
     JSR_BREAK
 } JStarStmtType;
 
+typedef struct FormalArg {
+    enum {
+        ARG,
+        UNPACK
+    } type;
+    union {
+        JStarIdentifier arg;
+        ext_vector(JStarIdentifier) unpack;
+    } as;
+} FormalArg;
+
 struct JStarDecl {
     ext_vector(JStarExpr*) decorators;
     bool isStatic;
@@ -146,7 +157,7 @@ struct JStarDecl {
         } var;
         struct {
             JStarIdentifier id;
-            ext_vector(JStarIdentifier) formalArgs;
+            ext_vector(FormalArg) formalArgs;
             ext_vector(JStarExpr*) defArgs;
             JStarIdentifier vararg;
             bool isGenerator;
@@ -154,7 +165,7 @@ struct JStarDecl {
         } fun;
         struct {
             JStarIdentifier id;
-            ext_vector(JStarIdentifier) formalArgs;
+            ext_vector(FormalArg) formalArgs;
             ext_vector(JStarExpr*) defArgs;
             JStarIdentifier vararg;
         } native;
@@ -234,7 +245,7 @@ JSTAR_API bool jsrIdentifierEq(const JStarIdentifier* id1, const JStarIdentifier
 // EXPRESSION NODES
 // -----------------------------------------------------------------------------
 
-JSTAR_API JStarExpr* jsrFuncLiteral(int line, ext_vector(JStarIdentifier) args,
+JSTAR_API JStarExpr* jsrFuncLiteral(int line, ext_vector(FormalArg) args,
                                     ext_vector(JStarExpr*) defArgs, JStarTok* vararg,
                                     bool isGenerator, JStarStmt* body);
 JSTAR_API JStarExpr* jsrTernaryExpr(int line, JStarExpr* cond, JStarExpr* thenExpr,
@@ -265,10 +276,10 @@ JSTAR_API void jsrExprFree(JStarExpr* e);
 // STATEMENT NODES
 // -----------------------------------------------------------------------------
 
-JSTAR_API JStarStmt* jsrFuncDecl(int line, JStarTok* name, ext_vector(JStarIdentifier) args,
+JSTAR_API JStarStmt* jsrFuncDecl(int line, JStarTok* name, ext_vector(FormalArg) args,
                                  ext_vector(JStarExpr*) defArgs, JStarTok* vararg, bool isGenerator,
                                  JStarStmt* body);
-JSTAR_API JStarStmt* jsrNativeDecl(int line, JStarTok* name, ext_vector(JStarIdentifier) args,
+JSTAR_API JStarStmt* jsrNativeDecl(int line, JStarTok* name, ext_vector(FormalArg) args,
                                    ext_vector(JStarExpr*) defArgs, JStarTok* vararg);
 JSTAR_API JStarStmt* jsrForStmt(int line, JStarStmt* init, JStarExpr* cond, JStarExpr* act,
                                 JStarStmt* body);

--- a/include/jstar/parse/ast.h
+++ b/include/jstar/parse/ast.h
@@ -275,17 +275,17 @@ JSTAR_API void jsrExprFree(JStarExpr* e);
 // STATEMENT NODES
 // -----------------------------------------------------------------------------
 
-JSTAR_API JStarStmt* jsrFuncDecl(int line, const JStarTok* name, const FormalArgs* args, bool isGenerator, JStarStmt* body);
-JSTAR_API JStarStmt* jsrNativeDecl(int line, JStarTok* name, const FormalArgs* args);
+JSTAR_API JStarStmt* jsrFuncDecl(int line, const JStarIdentifier* name, const FormalArgs* args, bool isGenerator, JStarStmt* body);
+JSTAR_API JStarStmt* jsrNativeDecl(int line, const JStarIdentifier* name, const FormalArgs* args);
 JSTAR_API JStarStmt* jsrForStmt(int line, JStarStmt* init, JStarExpr* cond, JStarExpr* act, JStarStmt* body);
-JSTAR_API JStarStmt* jsrClassDecl(int line, JStarTok* clsName, JStarExpr* sup, ext_vector(JStarStmt*) methods);
-JSTAR_API JStarStmt* jsrImportStmt(int line, ext_vector(JStarIdentifier) modules, ext_vector(JStarIdentifier) names, JStarTok* as);
+JSTAR_API JStarStmt* jsrClassDecl(int line, const JStarIdentifier* clsName, JStarExpr* sup, ext_vector(JStarStmt*) methods);
+JSTAR_API JStarStmt* jsrImportStmt(int line, ext_vector(JStarIdentifier) modules, ext_vector(JStarIdentifier) names, const JStarIdentifier* as);
 JSTAR_API JStarStmt* jsrVarDecl(int line, bool isUnpack, ext_vector(JStarIdentifier) ids, JStarExpr* init);
 JSTAR_API JStarStmt* jsrTryStmt(int line, JStarStmt* blck, ext_vector(JStarStmt*) excs, JStarStmt* ensure);
 JSTAR_API JStarStmt* jsrIfStmt(int line, JStarExpr* cond, JStarStmt* thenStmt, JStarStmt* elseStmt);
 JSTAR_API JStarStmt* jsrForEachStmt(int line, JStarStmt* varDecl, JStarExpr* iter, JStarStmt* body);
-JSTAR_API JStarStmt* jsrExceptStmt(int line, JStarExpr* cls, JStarTok* varName, JStarStmt* block);
-JSTAR_API JStarStmt* jsrWithStmt(int line, JStarExpr* e, JStarTok* varName, JStarStmt* block);
+JSTAR_API JStarStmt* jsrExceptStmt(int line, JStarExpr* cls, const JStarIdentifier* varName, JStarStmt* block);
+JSTAR_API JStarStmt* jsrWithStmt(int line, JStarExpr* e, const JStarIdentifier* varName, JStarStmt* block);
 JSTAR_API JStarStmt* jsrWhileStmt(int line, JStarExpr* cond, JStarStmt* body);
 JSTAR_API JStarStmt* jsrBlockStmt(int line, ext_vector(JStarStmt*) list);
 JSTAR_API JStarStmt* jsrReturnStmt(int line, JStarExpr* e);

--- a/include/jstar/parse/ast.h
+++ b/include/jstar/parse/ast.h
@@ -137,14 +137,20 @@ typedef enum JStarStmtType {
 
 typedef struct FormalArg {
     enum {
-        ARG,
+        SIMPLE,
         UNPACK
     } type;
     union {
-        JStarIdentifier arg;
+        JStarIdentifier simple;
         ext_vector(JStarIdentifier) unpack;
     } as;
 } FormalArg;
+
+typedef struct FormalArgs {
+    ext_vector(FormalArg) args;
+    ext_vector(JStarExpr*) defaults;
+    JStarIdentifier vararg;
+} FormalArgs;
 
 struct JStarDecl {
     ext_vector(JStarExpr*) decorators;
@@ -157,17 +163,13 @@ struct JStarDecl {
         } var;
         struct {
             JStarIdentifier id;
-            ext_vector(FormalArg) formalArgs;
-            ext_vector(JStarExpr*) defArgs;
-            JStarIdentifier vararg;
+            FormalArgs formalArgs;
             bool isGenerator;
             JStarStmt* body;
         } fun;
         struct {
             JStarIdentifier id;
-            ext_vector(FormalArg) formalArgs;
-            ext_vector(JStarExpr*) defArgs;
-            JStarIdentifier vararg;
+            FormalArgs formalArgs;
         } native;
         struct {
             JStarIdentifier id;
@@ -245,11 +247,8 @@ JSTAR_API bool jsrIdentifierEq(const JStarIdentifier* id1, const JStarIdentifier
 // EXPRESSION NODES
 // -----------------------------------------------------------------------------
 
-JSTAR_API JStarExpr* jsrFuncLiteral(int line, ext_vector(FormalArg) args,
-                                    ext_vector(JStarExpr*) defArgs, JStarTok* vararg,
-                                    bool isGenerator, JStarStmt* body);
-JSTAR_API JStarExpr* jsrTernaryExpr(int line, JStarExpr* cond, JStarExpr* thenExpr,
-                                    JStarExpr* elseExpr);
+JSTAR_API JStarExpr* jsrFuncLiteral(int line, const FormalArgs* args, bool isGenerator, JStarStmt* body);
+JSTAR_API JStarExpr* jsrTernaryExpr(int line, JStarExpr* cond, JStarExpr* thenExpr, JStarExpr* elseExpr);
 JSTAR_API JStarExpr* jsrCompundAssExpr(int line, JStarTokType op, JStarExpr* lval, JStarExpr* rval);
 JSTAR_API JStarExpr* jsrAccessExpr(int line, JStarExpr* left, const char* name, size_t length);
 JSTAR_API JStarExpr* jsrSuperLiteral(int line, JStarTok* name, JStarExpr* args);
@@ -276,21 +275,13 @@ JSTAR_API void jsrExprFree(JStarExpr* e);
 // STATEMENT NODES
 // -----------------------------------------------------------------------------
 
-JSTAR_API JStarStmt* jsrFuncDecl(int line, JStarTok* name, ext_vector(FormalArg) args,
-                                 ext_vector(JStarExpr*) defArgs, JStarTok* vararg, bool isGenerator,
-                                 JStarStmt* body);
-JSTAR_API JStarStmt* jsrNativeDecl(int line, JStarTok* name, ext_vector(FormalArg) args,
-                                   ext_vector(JStarExpr*) defArgs, JStarTok* vararg);
-JSTAR_API JStarStmt* jsrForStmt(int line, JStarStmt* init, JStarExpr* cond, JStarExpr* act,
-                                JStarStmt* body);
-JSTAR_API JStarStmt* jsrClassDecl(int line, JStarTok* clsName, JStarExpr* sup,
-                                  ext_vector(JStarStmt*) methods);
-JSTAR_API JStarStmt* jsrImportStmt(int line, ext_vector(JStarIdentifier) modules,
-                                   ext_vector(JStarIdentifier) names, JStarTok* as);
-JSTAR_API JStarStmt* jsrVarDecl(int line, bool isUnpack, ext_vector(JStarIdentifier) ids,
-                                JStarExpr* init);
-JSTAR_API JStarStmt* jsrTryStmt(int line, JStarStmt* blck, ext_vector(JStarStmt*) excs,
-                                JStarStmt* ensure);
+JSTAR_API JStarStmt* jsrFuncDecl(int line, const JStarTok* name, const FormalArgs* args, bool isGenerator, JStarStmt* body);
+JSTAR_API JStarStmt* jsrNativeDecl(int line, JStarTok* name, const FormalArgs* args);
+JSTAR_API JStarStmt* jsrForStmt(int line, JStarStmt* init, JStarExpr* cond, JStarExpr* act, JStarStmt* body);
+JSTAR_API JStarStmt* jsrClassDecl(int line, JStarTok* clsName, JStarExpr* sup, ext_vector(JStarStmt*) methods);
+JSTAR_API JStarStmt* jsrImportStmt(int line, ext_vector(JStarIdentifier) modules, ext_vector(JStarIdentifier) names, JStarTok* as);
+JSTAR_API JStarStmt* jsrVarDecl(int line, bool isUnpack, ext_vector(JStarIdentifier) ids, JStarExpr* init);
+JSTAR_API JStarStmt* jsrTryStmt(int line, JStarStmt* blck, ext_vector(JStarStmt*) excs, JStarStmt* ensure);
 JSTAR_API JStarStmt* jsrIfStmt(int line, JStarExpr* cond, JStarStmt* thenStmt, JStarStmt* elseStmt);
 JSTAR_API JStarStmt* jsrForEachStmt(int line, JStarStmt* varDecl, JStarExpr* iter, JStarStmt* body);
 JSTAR_API JStarStmt* jsrExceptStmt(int line, JStarExpr* cls, JStarTok* varName, JStarStmt* block);

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -138,8 +138,8 @@ struct Compiler {
 };
 
 static void initCompiler(Compiler* c, JStarVM* vm, Compiler* prev, ObjModule* module,
-                         const char* file, FuncType type, ext_vector(JStarIdentifier) * globals,
-                         ext_vector(FwdRef) * fwdRefs, const JStarStmt* ast) {
+                         const char* file, FuncType type, ext_vector(JStarIdentifier)* globals,
+                         ext_vector(FwdRef)* fwdRefs, const JStarStmt* ast) {
     vm->currCompiler = c;
     c->vm = vm;
     c->module = module;

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -165,7 +165,7 @@ static void endCompiler(Compiler* c) {
     ext_vec_foreach(char** it, c->synthetic_names) {
         free(*it);
     }
-    free(c->synthetic_names);
+    ext_vec_free(c->synthetic_names);
 
     if(c->prev != NULL) {
         c->prev->hadError |= c->hadError;

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -11,7 +11,7 @@
 
 typedef struct Compiler Compiler;
 
-ObjFunction* compile(JStarVM* vm, const char* filename, ObjModule* module, JStarStmt* s);
+ObjFunction* compile(JStarVM* vm, const char* filename, ObjModule* module, const JStarStmt* s);
 void reachCompilerRoots(JStarVM* vm, Compiler* c);
 
 #endif

--- a/src/lib/core/core.c
+++ b/src/lib/core/core.c
@@ -293,8 +293,8 @@ static JSR_NATIVE(jsr_Class_string) {
     jsrBufferPush(&str);
     return true;
 }
-
 // end
+
 // class Number
 JSR_NATIVE(jsr_Number_construct) {
     if(jsrIsNumber(vm, 1)) {
@@ -492,9 +492,10 @@ JSR_NATIVE(jsr_Generator_isDone) {
 
 JSR_NATIVE(jsr_Generator_string) {
     ObjGenerator* gen = AS_GENERATOR(vm->apiStack[0]);
+    const Prototype* proto = &gen->closure->fn->proto;
     JStarBuffer str;
     jsrBufferInit(vm, &str);
-    jsrBufferAppendf(&str, "<generator@%p>", (void*)gen);
+    jsrBufferAppendf(&str, "<Generator %s.%s@%p>", proto->module->name->data, proto->name->data, (void*)gen);
     jsrBufferPush(&str);
     return true;
 }

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -1,5 +1,5 @@
-// Format:opcode.de
-// Opcpde - Number of arguments - Number of values added (or removed) to the stack
+// The following is a list of all opcodes used by the VM. Each opcode follows this format:
+// OPCODE, number of args, number of values added (or removed) to the stack
 OPCODE(OP_ADD, 0, -1)
 OPCODE(OP_SUB, 0, -1)
 OPCODE(OP_MUL, 0, -1)

--- a/src/parse/ast.c
+++ b/src/parse/ast.c
@@ -157,7 +157,7 @@ JStarExpr* jsrCompundAssExpr(int line, JStarTokType op, JStarExpr* lval, JStarEx
 
 JStarExpr* jsrFuncLiteral(int line, const FormalArgs* args, bool isGenerator, JStarStmt* body) {
     JStarExpr* e = newExpr(line, JSR_FUNC_LIT);
-    e->as.funLit.func = jsrFuncDecl(line, &(JStarTok){0}, args, isGenerator, body);
+    e->as.funLit.func = jsrFuncDecl(line, &(JStarIdentifier){0}, args, isGenerator, body);
     return e;
 }
 
@@ -265,27 +265,27 @@ static JStarStmt* newDecl(int line, JStarStmtType type) {
 
 // Declarations
 
-JStarStmt* jsrFuncDecl(int line, const JStarTok* name, const FormalArgs* args, bool isGenerator, JStarStmt* body) {
+JStarStmt* jsrFuncDecl(int line, const JStarIdentifier* name, const FormalArgs* args, bool isGenerator, JStarStmt* body) {
     JStarStmt* f = newDecl(line, JSR_FUNCDECL);
-    f->as.decl.as.fun.id = (JStarIdentifier){name->length, name->lexeme};
+    f->as.decl.as.fun.id = *name;
     f->as.decl.as.fun.formalArgs = *args;
     f->as.decl.as.fun.body = body;
     f->as.decl.as.fun.isGenerator = isGenerator;
     return f;
 }
 
-JStarStmt* jsrNativeDecl(int line, JStarTok* name, const FormalArgs* args) {
+JStarStmt* jsrNativeDecl(int line, const JStarIdentifier* name, const FormalArgs* args) {
     JStarStmt* n = newDecl(line, JSR_NATIVEDECL);
-    n->as.decl.as.native.id = (JStarIdentifier){name->length, name->lexeme};
+    n->as.decl.as.native.id = *name;
     n->as.decl.as.native.formalArgs = *args;
     return n;
 }
 
-JStarStmt* jsrClassDecl(int line, JStarTok* clsName, JStarExpr* sup,
+JStarStmt* jsrClassDecl(int line, const JStarIdentifier* clsName, JStarExpr* sup,
                         ext_vector(JStarStmt*) methods) {
     JStarStmt* c = newDecl(line, JSR_CLASSDECL);
     c->as.decl.as.cls.sup = sup;
-    c->as.decl.as.cls.id = (JStarIdentifier){clsName->length, clsName->lexeme};
+    c->as.decl.as.cls.id = *clsName;
     c->as.decl.as.cls.methods = methods;
     return c;
 }
@@ -300,10 +300,10 @@ JStarStmt* jsrVarDecl(int line, bool isUnpack, ext_vector(JStarIdentifier) ids, 
 
 // Control flow statements
 
-JStarStmt* jsrWithStmt(int line, JStarExpr* e, JStarTok* varName, JStarStmt* block) {
+JStarStmt* jsrWithStmt(int line, JStarExpr* e, const JStarIdentifier* varName, JStarStmt* block) {
     JStarStmt* w = newStmt(line, JSR_WITH);
     w->as.withStmt.e = e;
-    w->as.withStmt.var = (JStarIdentifier){varName->length, varName->lexeme};
+    w->as.withStmt.var = *varName;
     w->as.withStmt.block = block;
     return w;
 }
@@ -353,11 +353,11 @@ JStarStmt* jsrBlockStmt(int line, ext_vector(JStarStmt*) list) {
 }
 
 JStarStmt* jsrImportStmt(int line, ext_vector(JStarIdentifier) modules,
-                         ext_vector(JStarIdentifier) names, JStarTok* as) {
+                         ext_vector(JStarIdentifier) names, const JStarIdentifier* as) {
     JStarStmt* s = newStmt(line, JSR_IMPORT);
     s->as.importStmt.modules = modules;
     s->as.importStmt.names = names;
-    s->as.importStmt.as = (JStarIdentifier){as->length, as->lexeme};
+    s->as.importStmt.as = *as;
     return s;
 }
 
@@ -375,11 +375,11 @@ JStarStmt* jsrTryStmt(int line, JStarStmt* blck, ext_vector(JStarStmt*) excs, JS
     return s;
 }
 
-JStarStmt* jsrExceptStmt(int line, JStarExpr* cls, JStarTok* varName, JStarStmt* block) {
+JStarStmt* jsrExceptStmt(int line, JStarExpr* cls, const JStarIdentifier* varName, JStarStmt* block) {
     JStarStmt* s = newStmt(line, JSR_EXCEPT);
     s->as.excStmt.block = block;
     s->as.excStmt.cls = cls;
-    s->as.excStmt.var = (JStarIdentifier){varName->length, varName->lexeme};
+    s->as.excStmt.var = *varName;
     return s;
 }
 

--- a/src/parse/ast.c
+++ b/src/parse/ast.c
@@ -483,7 +483,6 @@ void jsrStmtFree(JStarStmt* s) {
                 ext_vec_free(arg->as.unpack);
             }
         }
-        ext_vec_free(s->as.decl.as.fun.formalArgs);
         ext_vec_free(s->as.decl.as.native.formalArgs);
         ext_vec_foreach(JStarExpr** e, s->as.decl.as.native.defArgs) {
             jsrExprFree(*e);

--- a/src/parse/parser.c
+++ b/src/parse/parser.c
@@ -386,7 +386,7 @@ static FormalArgs formalArgs(Parser* p, JStarTokType open, JStarTokType close) {
         skipNewLines(p);
 
         if(match(p, TOK_EQUAL)) {
-            if(arg.type == UNPACK){
+            if(arg.type == UNPACK) {
                 error(p, "Unpack argument cannot have default value");
             }
 

--- a/src/parse/parser.c
+++ b/src/parse/parser.c
@@ -66,7 +66,7 @@ static void endFunction(Parser* p) {
 // ERROR REPORTING FUNCTIONS
 // -----------------------------------------------------------------------------
 
-static char* strchrnul(const char* str, char c) {
+static char* strchrWithNul(const char* str, char c) {
     char* ret;
     return (ret = strchr(str, c)) == NULL ? strchr(str, '\0') : ret;
 }
@@ -113,7 +113,7 @@ static void error(Parser* p, const char* msg, ...) {
         char error[MAX_ERR_SIZE];
         p->lineStart = correctEscapedNewlines(p->lineStart, errorTok->lexeme);
         int tokenCol = errorTok->lexeme - p->lineStart;
-        int lineLen = strchrnul(errorTok->lexeme, '\n') - p->lineStart;
+        int lineLen = strchrWithNul(errorTok->lexeme, '\n') - p->lineStart;
 
         int pos = printSourceSnippet(error, p->lineStart, lineLen, tokenCol);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -7,6 +7,7 @@
 #include "gc.h"
 #include "hashtable.h"
 #include "import.h"
+#include "jstar.h"
 #include "lib/builtins.h"
 #include "lib/core/core.h"
 #include "lib/core/excs.h"
@@ -98,6 +99,8 @@ JStarVM* jsrNewVM(const JStarConf* conf) {
 void jsrInitRuntime(JStarVM* vm) {
     // Core module bootstrap
     initCoreModule(vm);
+    // Initialize main module
+    jsrEvalModuleString(vm, "<main>", JSR_MAIN_MODULE, "");
     // Create empty tuple singleton
     vm->emptyTup = newTuple(vm, 0);
 }


### PR DESCRIPTION
Can now unpack function arguments:
```
fun unpack((a, b, c))
    print(a, b, c)
end

var pack = [1, 2, 3]
unpack(pack)
```